### PR TITLE
move flare setup to script and generated user.bazelrc entirely

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,33 +39,5 @@ build:bzlmod --xcode_version_config=@rules_cc.0.0.1.cc_configure.local_config_xc
 build --java_language_version=11
 build --tool_java_language_version=11
 
-# Remote features
-# Sensitive values are added to gitignored additional .bazelrc files
-build:flare --experimental_remote_merkle_tree_cache
-build:flare --experimental_remote_cache_async
-build:flare --incompatible_remote_build_event_upload_respect_no_cache
-common:flare --remote_upload_local_results=false
-common:flare --experimental_remote_downloader=grpcs://cache.bitrise.flare.build
-common:flare --remote_cache=grpcs://cache.bitrise.flare.build
-common:flare --remote_timeout=600
-common:flare --remote_max_connections=1000
-common:flare --remote_local_fallback
-build:flare --experimental_stream_log_file_uploads
-build:flare --incompatible_remote_results_ignore_disk
-build:flare --bes_backend=grpcs://bes.bitrise.flare.build:443
-build:flare --bes_results_url='https://insights.bitrise.flare.build/invocations/'
-build:flare --bes_upload_mode=fully_async
-build:flare --remote_download_toplevel
-build --config=flare
-fetch --config=flare
-
-common:flare_ci --remote_upload_local_results=true
-common:flare_ci --disk_cache=
-common:flare_ci --repository_cache=
-
-# misc
-build --nobuild_runfile_links
-test --build_runfile_links
-
 # User-specific .bazelrc
 try-import user.bazelrc

--- a/flare_ci_creds.sh
+++ b/flare_ci_creds.sh
@@ -3,6 +3,33 @@
 ENC_COMMIT_MSG=$(node --eval 'console.log(encodeURIComponent(process.argv[1]))' "${BITRISE_GIT_MESSAGE}")
 
 {
+    echo build:flare --experimental_remote_merkle_tree_cache
+    # don't use this for now, it can cause intermittent failures in some cases
+    # echo build:flare --experimental_remote_cache_async
+    echo build:flare --incompatible_remote_build_event_upload_respect_no_cache
+    echo common:flare --remote_upload_local_results=false
+    echo common:flare --experimental_remote_downloader=grpcs://cdn.bitrise.flare.build
+    echo common:flare --remote_cache=grpcs://cdn.bitrise.flare.build
+    echo common:flare --remote_timeout=600
+    echo common:flare --remote_max_connections=1000
+    echo common:flare --remote_local_fallback
+    echo build:flare --experimental_stream_log_file_uploads
+    echo build:flare --incompatible_remote_results_ignore_disk
+    echo build:flare --bes_backend=grpcs://bes.bitrise.flare.build:443
+    echo build:flare --bes_results_url='https://insights.bitrise.flare.build/invocations/'
+    echo build:flare --bes_upload_mode=fully_async
+    echo build:flare --remote_download_toplevel
+    echo build --config=flare
+    echo fetch --config=flare
+
+    echo common:flare_ci --remote_upload_local_results=true
+    echo common:flare_ci --disk_cache=
+    echo common:flare_ci --repository_cache=
+
+    # misc
+    echo build --nobuild_runfile_links
+    echo test --build_runfile_links
+
     echo common:flare --remote_header=x-api-key=${BITRISE_FLARE_KEY}
     echo common:flare --remote_header=x-flare-builduser=${BITRISE_FLARE_BUILD_USER}
     echo common:flare --bes_header=x-api-key=${BITRISE_FLARE_KEY}


### PR DESCRIPTION
also uses `cdn` endpoints, which we might want to change back to `cache.` later depending on stability and speed.